### PR TITLE
Version 0.1.2 with h2 dialect fixes

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -1,4 +1,4 @@
-VERSION_NUMBER = "0.1.2"
+VERSION_NUMBER = "0.2.0-SNAPSHOT"
 # Group identifier for your projects
 GROUP = "com.freiheit"
 COPYRIGHT = "freiheit.com technologies GmbH (2012)"


### PR DESCRIPTION
Sequence names where converted with toUpper() in the h2sql dialect, not anymore.
