### PR TITLE
Add checks for duplicate Column Names in TableDef

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ reports/
 *.ipr
 *.iws
 /*/*.iml
+/bin
+

--- a/core/src/main/java/com/freiheit/sqlapi4j/meta/TableDef.java
+++ b/core/src/main/java/com/freiheit/sqlapi4j/meta/TableDef.java
@@ -16,17 +16,19 @@
  */
 package com.freiheit.sqlapi4j.meta;
 
-import com.freiheit.sqlapi4j.generate.SqlDialect;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
 import com.freiheit.sqlapi4j.query.FromDef;
 import com.freiheit.sqlapi4j.query.FromDefVisitor;
 import com.freiheit.sqlapi4j.query.impl.JoinDecl;
 import com.freiheit.sqlapi4j.query.impl.OnPart;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * Metadata for a database table.
@@ -58,9 +60,21 @@ public class TableDef implements FromDef {
 			_colIndizes.put( col, Integer.valueOf( i));
 			++i;
 		}
+        validateColumnNames();
 	}
 
-	/**
+	private void validateColumnNames() {
+	    final Set<String> names = new HashSet<String>();
+	    for (final AbstractColumnDef<?> col : _columns) {
+	        final String name = col.fqName();
+	        if (names.contains(name)) {
+	            throw new IllegalArgumentException("name '" + name + "' is not unique!");
+	        }
+	        names.add(name);
+	    }
+    }
+
+    /**
 	 * @param tableName the table name
 	 * @param cols the table's column definitions
 	 */
@@ -76,6 +90,7 @@ public class TableDef implements FromDef {
 			_colIndizes.put( col, Integer.valueOf( i));
 			++i;
 		}
+        validateColumnNames();
 	}
 
 	/**

--- a/core/src/main/java/com/freiheit/sqlapi4j/query/impl/CreateTableStatementImpl.java
+++ b/core/src/main/java/com/freiheit/sqlapi4j/query/impl/CreateTableStatementImpl.java
@@ -33,4 +33,10 @@ public final class CreateTableStatementImpl implements CreateTableStatement {
     public TableDef getTable() {
         return _table;
     }
+
+    @Override
+    public String toString() {
+        return "CreateTableStatementImpl " + _table.getTableName();
+    }
+    
 }

--- a/core/src/test/java/com/freiheit/sqlapi4j/test/hsql/InsertUpdateTest.java
+++ b/core/src/test/java/com/freiheit/sqlapi4j/test/hsql/InsertUpdateTest.java
@@ -131,7 +131,8 @@ public class InsertUpdateTest extends TestBase {
 
     @Test
     public void testInsertWithAutoIncrementCol() throws SQLException {
-        final SqlCommand<InsertStatement> insert= SQL.insert(TestDb.Cat.TABLE).values(TestDb.Cat.ID.set(1l), TestDb.Cat.NAME.set("Garfield"));
+        final SqlCommand<InsertStatement> insert= SQL.insert(TestDb.Cat.TABLE).values( //TestDb.Cat.ID.set(1l),
+                TestDb.Cat.NAME.set("Garfield"));
 
         System.out.println( EXEC.render(insert.stmt()));
 

--- a/core/src/test/java/com/freiheit/sqlapi4j/test/hsql/InsertUpdateTest.java
+++ b/core/src/test/java/com/freiheit/sqlapi4j/test/hsql/InsertUpdateTest.java
@@ -22,6 +22,10 @@ import java.sql.SQLException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.freiheit.sqlapi4j.meta.ColumnDefNullable;
+import com.freiheit.sqlapi4j.meta.ColumnDefs;
+import com.freiheit.sqlapi4j.meta.SequenceDef;
+import com.freiheit.sqlapi4j.meta.TableDef;
 import com.freiheit.sqlapi4j.query.InsertCommand;
 import com.freiheit.sqlapi4j.query.SelectResult;
 import com.freiheit.sqlapi4j.query.SqlCommand;
@@ -142,6 +146,32 @@ public class InsertUpdateTest extends TestBase {
                 return null;
             }
         });
+    }
+    
+    @Test
+    public void testDoubleRowSameTypes() throws Exception {
+        final String name = "nonUniqueName";
+        final ColumnDefNullable<String> STRING1= ColumnDefs.varcharNullable( name);
+        final ColumnDefNullable<String> STRING2= ColumnDefs.varcharNullable( name);
+        try {
+            new TableDef( "doubleTableSameTypes", STRING1, STRING2);
+            Assert.fail("expected exception");
+        } catch (IllegalArgumentException e) {
+            // expected!
+        }
+    }
+
+    @Test
+    public void testDoubleRowDifferentTypes() throws Exception {
+        final String name = "nonUniqueName";
+        final ColumnDefNullable<String> STRING1= ColumnDefs.varcharNullable( name);
+        final ColumnDefNullable<Country> ENUM1= ColumnDefs.enumTypeNullable( name, Country.class);
+        try {
+            new TableDef( "doubleTableDiffTypes", STRING1, ENUM1);
+            Assert.fail("expected exception");
+        } catch (IllegalArgumentException e) {
+            // expected!
+        }
     }
 
     private static InsertCommand insertAddress( final long id, final String city, final String street, final int num, final String zip, final Country country) {


### PR DESCRIPTION
Now when you add multiple Columns with the same name to a TableDef, it will throw IllegalArgumentExceptions immediately (which usually means at startup of your application).
Before, you would get ArrayIndexOutOfBoundsException (or possible others) in your ResultTransformer when executing select statements.

Also repaired the InsertUpdateTest and increased the version number.
