### PR TITLE
CalendarColumnConverter: Fixed null handling and precision with DateT…

### DIFF
--- a/core/src/main/java/com/freiheit/sqlapi4j/meta/impl/CalendarColumnConverter.java
+++ b/core/src/main/java/com/freiheit/sqlapi4j/meta/impl/CalendarColumnConverter.java
@@ -56,6 +56,11 @@ public class CalendarColumnConverter implements ColumnConverter<Calendar,java.ut
 
 	@Override
 	public java.util.Date toDb( Calendar value, DbType<Calendar> dbType) {
+	    
+	    if (value == null) {
+	        return null;
+	    }
+	    
 		switch( _sqlType) {
 		case Types.TIMESTAMP:
 			return new Timestamp( value.getTimeInMillis());

--- a/core/src/main/java/com/freiheit/sqlapi4j/meta/impl/CalendarColumnConverter.java
+++ b/core/src/main/java/com/freiheit/sqlapi4j/meta/impl/CalendarColumnConverter.java
@@ -16,7 +16,7 @@
  */
 package com.freiheit.sqlapi4j.meta.impl;
 
-import java.sql.Date;
+import java.util.Date;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Calendar;
@@ -40,6 +40,10 @@ public class CalendarColumnConverter implements ColumnConverter<Calendar,java.ut
 
 	@Override
 	public Calendar fromDb( java.util.Date value, DbType<Calendar> dbType) {
+	    if (value == null) {
+	        return null;
+	    }
+	    
 		Calendar res= Calendar.getInstance();
 		res.setTimeInMillis( value.getTime());
 		return res;


### PR DESCRIPTION
…ime values.
- Null handling was broken.
- using java.util.Date instead of java.sql.Date.
  java.sql.Date drops the Time and only stores the Date.
